### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ module.exports = defineConfig({
     3. Providing it as a command line argument `--env` in the terminal when opening the Cypress runner.
     
     ```shell
-    npx cypress open -- env enableAccessibilityVoice=true
+    npx cypress open --env enableAccessibilityVoice=true
     ```
 
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -529,8 +529,8 @@ MIT License. See the [LICENSE](LICENSE) file for more details.
 
 ### v1.1.2
 
-- Fix issue with `accessibilityFolder` cofiguration parameter when missing char `/` at the end
-- Add axe-core® to the sorce code and documentation to be compliant with Deque trademark
+- Fix issue with `accessibilityFolder` configuration parameter when missing char `/` at the end
+- Add axe-core® to the source code and documentation to be compliant with Deque trademark
 - Created `.gitignore`
 
 ### v1.1.1


### PR DESCRIPTION
Removed space between -- and env.
This extra space stops 'env' from being interpreted correctly.