### PR TITLE
feat: change "fs.move" to "fs.copy" in \src\accessibility-task.js

### DIFF
--- a/cypress/e2e/all.js
+++ b/cypress/e2e/all.js
@@ -10,7 +10,7 @@ describe.skip('TEST SUITE 1', { tags: ['@accessibility'] }, () => {
         cy.visit('https://parabank.parasoft.com/parabank/index.htm')
         cy.wait(2000) // Using cy.wait(TIME) is a very bad practice, but it is used for simplicity in this example
 
-        cy.checkAccessibility(null, { includedImpacts: ['critical', 'serious', 'moderate', 'minor'] })
+        cy.checkAccessibility(null, { includedImpacts: ['critical', 'serious', 'moderate', 'minor'], skipFailures: true })
     });
 
     context('Context 1', () => {

--- a/src/accessibility-commands.js
+++ b/src/accessibility-commands.js
@@ -22,7 +22,7 @@ const defaultOptions = {
  * Cypress custom commant to check the accessibility of a given context using Cypress and Axe. Only consider DOM elements that are visible on the screen.
  * For more details regarding parameters and options refer to https://www.deque.com/axe/core-documentation/api-documentation/, https://github.com/dequelabs/axe-core and https://www.npmjs.com/package/cypress-axe.
  * @public
- * 
+ *
  * @param {string | Element | NodeList | Object} [context] - (optional) Axe-core® plugin parameter - Defines the scope of the analysis - the part of the DOM that you would like to analyze. This will typically be a CSS Selector, and DOM Element such as returned by document.getElementById("content"), a NodeList such as returned by document.querySelectorAll, or an Object. By default the analysis will be done for the full document.
  * @param {Object} [context.exclude] - (optional) Axe-core® plugin option - An object with exclude properties to specify elements that should not be tested. E.g. { exclude: ['button'] }.
  * @param {Object} [context.include] - (optional) Axe-core® plugin option - An object with include properties to specify elements that should be tested. E.g. { include: ['button'] }.
@@ -42,6 +42,7 @@ const defaultOptions = {
  * @param {string[]} [options.includedImpacts=['critical', 'serious']] - (optional) CYPRESS-AXE plugin option - Violations to include in the accessibility analysis. Map to impact levels in violations, where possible impact values are "minor", "moderate", "serious", or "critical". By default { includedImpacts: ['critical', 'serious'] }.
  * @param {integer} [options.retries=0] - (optional) CYPRESS-AXE plugin option - Number of times to retry the check if there are initial findings. By default 0.
  * @param {integer} [options.interval=1000] - (optional) CYPRESS-AXE plugin option - Number of milliseconds to wait between retries. By default 1000 (1 second)
+ * @param {boolean} [options.skipFailures=false] - (optional) CYPRESS-AXE plugin option - This enabled you to see violations while allowing your tests to pass. This should be used as a temporary measure while you address accessibility violations.
  * @param {string[]} [options.runOnly=['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice']] - (optional) Axe-core® plugin option - Limit which rules are executed, based on names or tags. By default { runOnly: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'] }.
  * @param {Object} [options.rules] - (optional) Axe-core® plugin option - Enable or disable rules using the enabled property. E.g. { rules: { 'color-contrast': { enabled: false }, 'valid-lang': { enabled: false } }}.
  * @param {string} [options.reporter] - (optional) Axe-core® plugin option - Which reporter to use. E.g. { reporter: 'v2'}.
@@ -66,12 +67,13 @@ const checkAccessibility = (context, options) => {
 
     Cypress.env('accessibilityContext', context)
     Cypress.env('accessibilityOptions', options)
-    
+
     cy.injectAxe()
     cy.checkA11y(
         context,
         options,
-        options.generateReport ? logViolationsAndGenerateReport : logViolations
+        options.generateReport ? logViolationsAndGenerateReport : logViolations,
+        options.skipFailures
     )
 }
 Cypress.Commands.add('checkAccessibility', checkAccessibility)

--- a/src/accessibility-tasks.js
+++ b/src/accessibility-tasks.js
@@ -24,8 +24,8 @@ const addAccessibilityTasks = (on) => {
         }
     }
 
-    let specResults = newSpecResults() 
-    
+    let specResults = newSpecResults()
+
     on('task', {
         /**
          * Clears the spec results.
@@ -102,7 +102,7 @@ const addAccessibilityTasks = (on) => {
                     // Folder must exist in order to create the report
                     if (err) {
                         const msg = `FAILED TO GENERATE ACCESSIBILITY REPORT AT: ${filePath}`
-                        console.error(err);
+                        error(err);
 
                         resolve(`❌❌❌❌ **${msg}**`) // Inform the user that the report was not generated but do not fail the test
                         // return reject(err)  // Fail the test
@@ -141,9 +141,9 @@ const addAccessibilityTasks = (on) => {
          */
         moveScreenshotToFolder({ originFilePath, targetFilePath }) {
             return new Promise((resolve, reject) => {
-                fs.move(path.resolve(originFilePath), path.resolve(targetFilePath), err => {
+                fs.copy(path.resolve(originFilePath), path.resolve(targetFilePath), err => {
                     if (err) {
-                        console.error(err)
+                        error(err)
                         reject(err)
                     } else {
                         resolve(`SUCCESSFULLY MOVED SCREENSHOT TO: ${targetFilePath}`)
@@ -153,7 +153,7 @@ const addAccessibilityTasks = (on) => {
         }
     })
 
-    
+
 }
 
 module.exports = addAccessibilityTasks


### PR DESCRIPTION
1. To add compatibility with Allure reporter, I changed the fs-extra method from move to copy the screenshots, to prevent allure reporter from throwing the error.
2. To add "skipFailures" options to pass in checkAccessibility method