### PR TITLE
Updated violation screenshot to include nested paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wick-a11y",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cypress plugin to perform configurable accessibility tests using AXE. It provides a list of violations and detailed information in the Cypress log, and generates an HTML document that includes screenshots of each violation on the page. The plugin leverages both cypress-axe and axe-core to deliver comprehensive accessibility testing.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/accessibility-report.js
+++ b/src/accessibility-report.js
@@ -146,7 +146,12 @@ const takeScreenshotsViolations = (reportId, reportFolder) => {
 
     let subFolder = ''
     if (!Cypress.config('isInteractive')) {
-        subFolder = `${Cypress.spec.name}/` // If executed in run mode it creates a folder with test name for the screenshots
+        // Using the relative path instead of just spec.name
+        let specRelative = Cypress.spec.relative.replace(/\\/g, '/');
+        // Removing "cypress/e2e/" if the project uses that as a top-level folder
+        specRelative = specRelative.replace(/^cypress\/e2e\//, '');
+        // Append a slash, keeping the entire file name for minimal change
+        subFolder = `${specRelative}/`;
     }
 
     const targetFileName = `${issuesFileNameTarget}${attemptSuffix}.png`


### PR DESCRIPTION
Summary:
This pull request resolves the bug where the HTML violation report fails due to the screenshot path being stored in folders deeper than two levels. The core issue was that Cypress.spec.name only handled a single or shallow folder structure, leading to a mismatch between the actual screenshot location and the file path used in the violation report.

Changes:
Replaced Cypress.spec.name with Cypress.spec.relative to dynamically capture and construct paths for nested test files.
Replaced the code that only resolved a flat directory structure.
Ensured that screenshots now populate correctly in the final HTML report for both shallow and deeply nested tests.

Testing:
Verified that tests in nested directories (e.g., level1/level2/level3) successfully generate screenshots in the correct location.
Confirmed the HTML violation reports include all screenshots without throwing file-path errors.

This PR resolves bug: https://github.com/sclavijosuero/wick-a11y/issues/21