### PR TITLE
Fix: Report Generation Fails with ENOENT Error on --spec Runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wick-a11y",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Cypress plugin to perform configurable accessibility tests using AXE. It provides a list of violations and detailed information in the Cypress log, and generates an HTML document that includes screenshots of each violation on the page. The plugin leverages both cypress-axe and axe-core to deliver comprehensive accessibility testing.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/accessibility-tasks.js
+++ b/src/accessibility-tasks.js
@@ -140,15 +140,24 @@ const addAccessibilityTasks = (on) => {
          * @returns {Promise<string>} A promise that resolves with a success message if the file is moved successfully, or rejects with an error if there was an issue moving the file.
          */
         moveScreenshotToFolder({ originFilePath, targetFilePath }) {
-            return new Promise((resolve, reject) => {
-                fs.copy(path.resolve(originFilePath), path.resolve(targetFilePath), err => {
-                    if (err) {
-                        console.error(err)
-                        reject(err)
-                    } else {
-                        resolve(`SUCCESSFULLY MOVED SCREENSHOT TO: ${targetFilePath}`)
-                    }
-                })
+            // Get the directory from the full target file path
+            const targetDir = path.dirname(targetFilePath);
+
+            // First, ensure the target directory exists. Then, copy the file.
+            // This returns the promise chain directly.
+            return fs.ensureDir(targetDir).then(() => {
+                // This returns the promise from fs.copy
+                return fs.copy(originFilePath, targetFilePath);
+            }).then(() => {
+                // This is the success case after the copy completes
+                const successMessage = `SUCCESSFULLY MOVED SCREENSHOT TO: ${targetFilePath}`;
+                // console.log(successMessage); // Optional: uncomment for debugging
+                return successMessage;
+            }).catch((err) => {
+                // This single .catch handles errors from both ensureDir and copy
+                console.error(`Error moving screenshot to '${targetFilePath}'`,err);
+                // Re-throw the error to ensure the promise is rejected, failing the task
+                throw err;
             })
         }
     })


### PR DESCRIPTION
## Summary:
This pull request resolves a bug introduced by the fix for https://github.com/sclavijosuero/wick-a11y/issues/21. The previous changes, while correcting pathing for nested tests in a full run, inadvertently broke the path-handling logic when a single test is executed via the cypress run --spec flag.

The root cause was that the report generation script was incorrectly using the entire spec file path as a directory, leading to an ENOENT: no such file or directory error and preventing the HTML report from being created.

## Changes:
The logic for determining the report's asset paths has been updated to reliably extract the parent directory from Cypress.spec.relative using path.dirname(). This ensures we always get a valid directory path, whether running all tests or a single spec.

## Testing:
The fix was validated across the multiple scenarios listed, In all test cases, the HTML violation reports were created successfully with their corresponding screenshots, and no path-related errors were thrown.

### 1. Direct Bug Verification (--spec flag):
- Successfully ran single tests located at the root, in shallow folders, and in deeply nested folders using `npx cypress run --spec "path/to/my/test.spec.js"`. The HTML report was generated correctly in all cases.

### 2. Original Bug Regression Check (Full Run):
- Executed the entire test suite via `npx cypress run`. All reports for tests at varying nesting levels were generated successfully, confirming that the fix for https://github.com/sclavijosuero/wick-a11y/issues/21 remains intact.

### 3. Environment and Mode Verification:
- Interactive Mode: Ran all tests via `npx cypress open` and confirmed that reports were generated correctly without errors.

### 4. Project Structure: 
- Verified the fix works correctly with the cypress folder located both at the project root (/cypress) and within a nested subdirectory (/some/folder/cypress).


<img width="1159" height="541" alt="Screenshot 2025-08-25 at 11 48 33 AM" src="https://github.com/user-attachments/assets/348d4978-77af-45be-8c4b-600a3e1fe171" />
