### PR TITLE
Fix Typescript types: allow 'basic' and 'detailed' options for generateReport

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,7 +51,7 @@ declare global {
                     fromShadowDom?: object;
                 },
                 options?: {
-                    generateReport?: boolean;
+                    generateReport?: boolean | 'basic' | 'detailed';
                     impactStyling?: Record<string, { icon: string; style: string }>;
                     includedImpacts?: string[];
                     onlyWarnImpacts?: string[];


### PR DESCRIPTION
**Problem**
The TypeScript type definition for generateReport in src/index.d.ts only allows boolean. However, since v2.5.0, the library supports 'basic' and 'detailed' as valid values for generating simplified HTML reports (as documented in the README and implemented in accessibility-commands.js). 
This causes TypeScript errors when using the documented feature:
`cy.checkAccessibility(null, { generateReport: 'basic' })`

**Changes**
Update the type definition to:
`generateReport?: boolean | 'basic' | 'detailed'`